### PR TITLE
 fix loss calculation for VAE

### DIFF
--- a/mmvae/trainers/ExampleTrainer.py
+++ b/mmvae/trainers/ExampleTrainer.py
@@ -5,6 +5,7 @@ import mmvae.models.ExampleModel as ExampleModel
 from mmvae.trainers.trainer import BaseTrainer
 from mmvae.data import MultiModalLoader, ChunkedCellCensusDataLoader
 
+
 class ExampleTrainer(BaseTrainer):
     """
     Trainer class designed for MMVAE model using MutliModalLoader.
@@ -14,40 +15,52 @@ class ExampleTrainer(BaseTrainer):
     dataloader: MultiModalLoader
 
     def __init__(self, batch_size, *args, **kwargs):
-        self.batch_size = batch_size # Defined before super().__init__ as configure_* is called on __init__
+        # Defined before super().__init__ as configure_* is called on __init__
+        self.batch_size = batch_size
         super(ExampleTrainer, self).__init__(*args, **kwargs)
         self.model.to(self.device)
-        self.expert_class_indices = [i for i in range(len(self.model.experts)) ]
+        self.expert_class_indices = [i for i in range(len(self.model.experts))]
 
     def configure_dataloader(self):
-        expert1 = ChunkedCellCensusDataLoader('expert1', directory_path="/active/debruinz_project/tony_boos/csr_chunks", masks=['chunk*'], batch_size=self.batch_size, num_workers=2)
-        expert2 = ChunkedCellCensusDataLoader('expert2', directory_path="/active/debruinz_project/tony_boos/csr_chunks", masks=['chunk*'], batch_size=self.batch_size, num_workers=2)
+        expert1 = ChunkedCellCensusDataLoader('expert1', directory_path="/active/debruinz_project/tony_boos/csr_chunks", masks=[
+                                              'chunk*'], batch_size=self.batch_size, num_workers=2)
+        expert2 = ChunkedCellCensusDataLoader('expert2', directory_path="/active/debruinz_project/tony_boos/csr_chunks", masks=[
+                                              'chunk*'], batch_size=self.batch_size, num_workers=2)
         return MultiModalLoader(expert1, expert2)
 
     def configure_model(self):
         return ExampleModel.configure_model(num_experts=2)
-    
+
     def configure_optimizers(self) -> dict[str, torch.optim.Optimizer]:
         optimizers = {}
         for name in self.model.experts.keys():
             expert = self.model.experts[name]
-            optimizers[f'{name}-enc'] = torch.optim.Adam(expert.encoder.parameters())
-            optimizers[f'{name}-dec'] = torch.optim.Adam(expert.decoder.parameters())
-            optimizers[f'{name}-disc'] = torch.optim.Adam(expert.discriminator.parameters())
+            optimizers[f'{
+                name}-enc'] = torch.optim.Adam(expert.encoder.parameters())
+            optimizers[f'{
+                name}-dec'] = torch.optim.Adam(expert.decoder.parameters())
+            optimizers[f'{
+                name}-disc'] = torch.optim.Adam(expert.discriminator.parameters())
 
-        optimizers['shr_enc_disc'] = torch.optim.Adam(self.model.shared_vae.encoder.discriminator.parameters())
-        optimizers['shr_vae'] = torch.optim.Adam(list(self.model.shared_vae.encoder.parameters()) + list(self.model.shared_vae.decoder.parameters()))
+        optimizers['shr_enc_disc'] = torch.optim.Adam(
+            self.model.shared_vae.encoder.discriminator.parameters())
+        optimizers['shr_vae'] = torch.optim.Adam(list(self.model.shared_vae.encoder.parameters(
+        )) + list(self.model.shared_vae.decoder.parameters()))
         return optimizers
 
-    def vae_loss(self, predicted, target, mu, sigma, kl_weight = 1):
-        vae_recon_loss = F.mse_loss(predicted, target)
-        kl_loss = utils.kl_divergence(mu, sigma)
+    def vae_loss(self, predicted, target, mu, sigma, kl_weight=1):
+        # sum over the input dimensions then mean over the batch
+        vae_recon_loss = F.mse_loss(
+            predicted, target, reduction=None).sum(dim=1).mean()
+        kl_loss = utils.kl_divergence(mu, sigma, reduction="mean")
         return vae_recon_loss + kl_loss * kl_weight
-    
+
     def expert_discriminator_loss(self, data, expert, real=True):
         output = self.model.experts[expert].discriminator(data)
-        labels = torch.ones(output.size(), device=self.device) if real else torch.zeros(output.size(), device=self.device)
-        loss = F.binary_cross_entropy(output, labels)
+        labels = torch.ones(output.size(), device=self.device) if real else torch.zeros(
+            output.size(), device=self.device)
+        loss = F.binary_cross_entropy(
+            output, labels)
         return loss
 
     def train_epoch(self, epoch):
@@ -55,9 +68,10 @@ class ExampleTrainer(BaseTrainer):
             print("Starting Iteration", iteration, flush=True)
             self.model.set_expert(expert)
             train_data = data.to(self.device)
-            
+
             # Forwad Pass Over Entire Model
-            shared_input, shared_output, mu, var, shared_encoder_outputs, shared_decoder_outputs, expert_output = self.model(train_data)
+            shared_input, shared_output, mu, var, shared_encoder_outputs, shared_decoder_outputs, expert_output = self.model(
+                train_data)
 
             # Train Expert Discriminator
             if iteration % 5 == 0:
@@ -68,7 +82,8 @@ class ExampleTrainer(BaseTrainer):
                 real_loss = self.expert_discriminator_loss(train_data, expert)
                 real_loss.backward()
                 # Train discriminator on fake data
-                fake_loss = self.expert_discriminator_loss(expert_output.detach(), expert, real=False)
+                fake_loss = self.expert_discriminator_loss(
+                    expert_output.detach(), expert, real=False)
                 # Update Expert Discriminator Gradients
                 fake_loss.backward()
                 opt_exp_disc.step()
@@ -77,26 +92,34 @@ class ExampleTrainer(BaseTrainer):
             self.optimizers['shr_vae'].zero_grad()
             self.optimizers['shr_enc_disc'].zero_grad()
             # Expert Reconstruction Loss
-            expert_recon_loss = F.mse_loss(expert_output, train_data.to_dense())
+            expert_recon_loss = F.mse_loss(
+                expert_output, train_data.to_dense())
             # Shared VAE Loss
             vae_loss = self.vae_loss(shared_output, shared_input, mu, var)
             # Shared Encoder Adverserial Feedback
-            labels = torch.tensor([self.expert_class_indices] * 32, dtype=float, device=self.device)
-            shr_enc_adversial_loss = F.cross_entropy(shared_encoder_outputs, labels)
+            labels = torch.tensor(
+                [self.expert_class_indices] * 32, dtype=float, device=self.device)
+            shr_enc_adversial_loss = F.cross_entropy(
+                shared_encoder_outputs, labels)
             # Shared Expert Discriminator Loss
-            shared_loss = self.expert_discriminator_loss(expert_output.detach(), expert, real=False)
-            adv_weight = -0.1 # TODO: Add annealing factor
-            total_loss = expert_recon_loss + vae_loss + adv_weight * shr_enc_adversial_loss + shared_loss
+            shared_loss = self.expert_discriminator_loss(
+                expert_output.detach(), expert, real=False)
+            adv_weight = -0.1  # TODO: Add annealing factor
+            total_loss = expert_recon_loss + vae_loss + \
+                adv_weight * shr_enc_adversial_loss + shared_loss
             total_loss.backward()
-        
+
             self.optimizers['shr_enc_disc'].step()
             self.optimizers['shr_vae'].step()
             self.optimizers[f'{expert}-enc'].step()
             self.optimizers[f'{expert}-dec'].step()
 
-            self.writer.add_scalar('Loss/Expert_Recon', expert_recon_loss.item(), iteration)
+            self.writer.add_scalar('Loss/Expert_Recon',
+                                   expert_recon_loss.item(), iteration)
             self.writer.add_scalar('Loss/VAE', vae_loss.item(), iteration)
-            self.writer.add_scalar('Loss/Shared_Encoder_Adversarial', shr_enc_adversial_loss.item(), iteration)
-            self.writer.add_scalar('Loss/Shared', shared_loss.item(), iteration)
+            self.writer.add_scalar(
+                'Loss/Shared_Encoder_Adversarial', shr_enc_adversial_loss.item(), iteration)
+            self.writer.add_scalar(
+                'Loss/Shared', shared_loss.item(), iteration)
             self.writer.add_scalar('Loss/Total', total_loss.item(), iteration)
             self.writer.flush()

--- a/mmvae/trainers/HumanVAE.py
+++ b/mmvae/trainers/HumanVAE.py
@@ -6,6 +6,7 @@ import mmvae.models.HumanVAE as HumanVAE
 from mmvae.trainers.trainer import BaseTrainer
 from mmvae.data import MappedCellCensusDataLoader
 
+
 class HumanVAETrainer(BaseTrainer):
     """
     Trainer class designed for MMVAE model using MutliModalLoader.
@@ -15,14 +16,15 @@ class HumanVAETrainer(BaseTrainer):
     dataloader: MappedCellCensusDataLoader
 
     def __init__(self, batch_size, *args, **kwargs):
-        self.batch_size = batch_size # Defined before super().__init__ as configure_* is called on __init__
+        # Defined before super().__init__ as configure_* is called on __init__
+        self.batch_size = batch_size
         super(HumanVAETrainer, self).__init__(*args, **kwargs)
         self.model.to(self.device)
         self.annealing_steps = 50
 
     def configure_model(self) -> Module:
-        return HumanVAE.configure_model() 
-    
+        return HumanVAE.configure_model()
+
     def configure_dataloader(self):
         return MappedCellCensusDataLoader(
             batch_size=self.batch_size,
@@ -30,14 +32,14 @@ class HumanVAETrainer(BaseTrainer):
             file_path='/active/debruinz_project/CellCensus_3M/3m_human_chunk_10.npz',
             load_all=True
         )
-    
+
     def configure_optimizers(self):
         return {
             'encoder': torch.optim.Adam(self.model.expert.encoder.parameters(), lr=0.0001),
             'decoder': torch.optim.Adam(self.model.expert.decoder.parameters(), lr=0.0001),
             'shr_vae': torch.optim.Adam(self.model.shared_vae.parameters(), lr=.00001)
         }
-    
+
     def configure_schedulers(self):
         from torch.optim.lr_scheduler import StepLR
         return {}
@@ -46,11 +48,11 @@ class HumanVAETrainer(BaseTrainer):
             'decoder': StepLR(self.optimizers['decoder'], step_size=30, gamma=0.1),
             'shr_vae': StepLR(self.optimizers['shr_vae'], step_size=30, gamma=0.1)
         }
-    
+
     def train(self, epochs, load_snapshot=False):
         self.batch_iteration = 0
         super().train(epochs, load_snapshot)
-    
+
     def train_epoch(self, epoch):
         for train_data in self.dataloader:
             self.batch_iteration += 1
@@ -64,16 +66,18 @@ class HumanVAETrainer(BaseTrainer):
 
         # Forwad Pass Over Entire Model
         x_hat, mu, var = self.model(train_data)
-        recon_loss = F.l1_loss(x_hat, train_data.to_dense())
+        recon_loss = F.MSE(x_hat, train_data.to_dense(),
+                           reduction=None).sum(dim=1).mean()
         # Shared VAE Loss
-        kl_loss = utils.kl_divergence(mu, var)
+        kl_loss = utils.kl_divergence(mu, var, reduction="mean")
         kl_weight = min(1.0, epoch / self.annealing_steps)
         loss = recon_loss + (kl_loss * kl_weight)
         loss.backward()
-    
+
         self.optimizers['shr_vae'].step()
         self.optimizers['encoder'].step()
         self.optimizers['decoder'].step()
 
         self.writer.add_scalar('Loss/KL', kl_loss.item(), self.batch_iteration)
-        self.writer.add_scalar('Loss/ReconstructionFromTrainingData', loss.item(), self.batch_iteration)
+        self.writer.add_scalar(
+            'Loss/ReconstructionFromTrainingData', loss.item(), self.batch_iteration)

--- a/mmvae/trainers/annealing.py
+++ b/mmvae/trainers/annealing.py
@@ -1,0 +1,56 @@
+import numpy as np
+import math
+
+
+class Annealing:
+    def frange_cycle_linear(start, stop, n_epoch, n_cycle=4, ratio=0.5):
+        L = np.ones(n_epoch)
+        period = n_epoch/n_cycle
+        step = (stop-start)/(period*ratio)  # linear schedule
+
+        for c in range(n_cycle):
+
+            v, i = start, 0
+            while v <= stop and (int(i+c*period) < n_epoch):
+                L[int(i+c*period)] = v
+                v += step
+                i += 1
+        return L
+
+    def frange_cycle_sigmoid(start, stop, n_epoch, n_cycle=4, ratio=0.5):
+        L = np.ones(n_epoch)
+        period = n_epoch/n_cycle
+        step = (stop-start)/(period*ratio)  # step is in [0,1]
+
+        # transform into [-6, 6] for plots: v*12.-6.
+        for c in range(n_cycle):
+            v, i = start, 0
+            while v <= stop:
+                L[int(i+c*period)] = 1.0/(1.0 + np.exp(- (v*12.-6.)))
+                v += step
+                i += 1
+        return L
+
+    #  function  = 1 − cos(a), where a scans from 0 to pi/2
+    def frange_cycle_cosine(start, stop, n_epoch, n_cycle=4, ratio=0.5):
+        L = np.ones(n_epoch)
+        period = n_epoch/n_cycle
+        step = (stop-start)/(period*ratio)  # step is in [0,1]
+
+        # transform into [0, pi] for plots:
+        for c in range(n_cycle):
+            v, i = start, 0
+            while v <= stop:
+                L[int(i+c*period)] = 0.5-.5*math.cos(v*math.pi)
+                v += step
+                i += 1
+        return L
+
+    def frange(start, stop, step, n_epoch):
+        L = np.ones(n_epoch)
+        v, i = start, 0
+        while v <= stop:
+            L[i] = v
+            v += step
+            i += 1
+        return L

--- a/mmvae/trainers/utils.py
+++ b/mmvae/trainers/utils.py
@@ -1,6 +1,7 @@
 import torch
 
-def kl_divergence(mu, logvar):
+
+def kl_divergence(mu, logvar, reduction="sum"):
     """
     Calculate the KL divergence between a given Gaussian distribution q(z|x)
     and the standard Gaussian distribution p(z).
@@ -12,4 +13,7 @@ def kl_divergence(mu, logvar):
     Returns:
     - torch.Tensor: The KL divergence.
     """
-    return -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())
+    if reduction == "sum":
+        return -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp(), dim=1)
+    if reduction == "mean":
+        return torch.mean(-0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp(), dim=1))


### PR DESCRIPTION
This PR update the calculation of reconstruction loss and KL loss , it's introduce additional parameter for method kl_divergent class utils ( reduction , default option is sum ). Also this PR adding new Annealing class consist of some annealing method

- Rather than doing **reduction mean** for MSE which is not account for loss of element wise (sum over feature dimension and divide by feature number * batch size). This new method sum over feature dimension and divide by batch size.
- Fix incorrect scaling between MSE and KL. Current implement of KL are scale over sum ` -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp())`. But MSE are scale over mean by default `F.mse_loss(predicted, target)`. This lead to imbalance between KL loss and MSE loss. We can clearly see that KL Loss easily drop to 0 at few epoch and make MSE loss converge earlier than expected.
- The reduction sum `F.mse_loss(predicted, target,reduction="sum")` propose earlier are correct but it's hard to interpret loss since the log of loss  are two high

=> This new method tried to fix all of the issue that note above by scale the reconstruction loss over batch size and KL over mean. The log of loss are smaller and easier to interpret

Below are **output** and **graph** compare between **reduction mean** method and **new method** for **mnist** and **chunk 10** data

# Reduction mean  - MNIST

## Reconstruction output and sample input
<img width="410" alt="Screenshot 2024-03-03 at 1 07 10 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/4b16e720-86da-4181-9b59-b88881265e6d">

## Graph
<img width="801" alt="Screenshot 2024-03-03 at 1 07 45 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/b87db6ef-794b-405e-9716-5aab0bb2a9f1">

# Reduction mean  - Chunk 10 Cell Data

## Graph
<img width="786" alt="Screenshot 2024-03-03 at 1 24 47 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/d119600e-0ee7-4c20-b6ca-4e9a4a2b1a1c">



# New Method - MNIST

## Reconstruction output and sample input 
<img width="432" alt="Screenshot 2024-03-03 at 1 17 54 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/faa8e73d-b7d8-4766-9670-663b23c18c93">

## Graph
<img width="795" alt="Screenshot 2024-03-03 at 1 18 34 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/4288e589-af30-49ae-8122-2970f38a2c44">

# New Method - Chunk 10

## Graph
<img width="780" alt="Screenshot 2024-03-03 at 1 25 38 AM" src="https://github.com/zdebruine/MMVAE/assets/60676245/ec25e498-12b9-46df-b7f6-c368b11e27f8">

log loss KL-Div / over latent space size
log loss Reconstruction / over input feature size


