### PR TITLE
Resolves Issue #37

### DIFF
--- a/src/cmmvae/models/cmmvae_model.py
+++ b/src/cmmvae/models/cmmvae_model.py
@@ -118,7 +118,7 @@ class CMMVAEModel(BaseModel):
         adversarial_optimizers = optims["adversarials"]
 
         # Perform forward pass and compute the loss
-        qz, pz, z, xhats, cg_xhats, hidden_representations = self.module(
+        qz, pz, z, xhats, hidden_representations = self.module(
             x, metadata, expert_id
         )
 
@@ -214,7 +214,7 @@ class CMMVAEModel(BaseModel):
         expert_label = self.module.experts.labels[expert_id]
 
         # Perform forward pass and compute the loss
-        qz, pz, z, xhats, cg_xhats, hidden_representations = self.module(
+        qz, pz, z, xhats, hidden_representations = self.module(
             x, metadata, expert_id
         )
 


### PR DESCRIPTION
Removes the depreciated Cross-Generation functionality. Updates the `cross_generate` flag in the `forward` method of `cmmvae.py` to control whether to use all, or one, expert decoder networks when producing `x_hat` outputs.