### PR TITLE
Resolves Issues #39 & #40

### DIFF
--- a/src/cmmvae/models/base_model.py
+++ b/src/cmmvae/models/base_model.py
@@ -338,3 +338,4 @@ class BaseModel(pl.LightningModule):
                     self.predict_dir, f"{key}_metadata_{self._curr_save_idx}.pkl"
                 ),
             )
+        self._running_predictions.clear()

--- a/src/cmmvae/models/cmmvae_model.py
+++ b/src/cmmvae/models/cmmvae_model.py
@@ -294,7 +294,7 @@ class CMMVAEModel(BaseModel):
             for expert_id in self.module.experts
         }
         optimizers["vae"] = torch.optim.Adam(
-            self.module.vae.encoder.parameters(), lr=1e-3, weight_decay=1e-6
+            self.module.vae.parameters(), lr=1e-3, weight_decay=1e-6
         )
         optimizers["adversarials"] = {
             i: torch.optim.Adam(module.parameters(), lr=1e-3, weight_decay=1e-6)

--- a/src/cmmvae/models/cmmvae_model.py
+++ b/src/cmmvae/models/cmmvae_model.py
@@ -118,7 +118,7 @@ class CMMVAEModel(BaseModel):
         adversarial_optimizers = optims["adversarials"]
 
         # Perform forward pass and compute the loss
-        qz, pz, z, xhats, cg_xhats, hidden_representations = self.module(
+        qz, pz, z, xhats, hidden_representations = self.module(
             x, metadata, expert_id
         )
 
@@ -214,7 +214,7 @@ class CMMVAEModel(BaseModel):
         expert_label = self.module.experts.labels[expert_id]
 
         # Perform forward pass and compute the loss
-        qz, pz, z, xhats, cg_xhats, hidden_representations = self.module(
+        qz, pz, z, xhats, hidden_representations = self.module(
             x, metadata, expert_id
         )
 

--- a/src/cmmvae/modules/cmmvae.py
+++ b/src/cmmvae/modules/cmmvae.py
@@ -136,4 +136,7 @@ class CMMVAE(nn.Module):
         # Encode using the VAE
         _, z, _ = self.vae.encode(x)
 
+        # Tag the metadata with the expert_id
+        metadata['species'] = expert_id
+
         return {RK.Z: z, f"{RK.Z}_{RK.METADATA}": metadata}


### PR DESCRIPTION
Updated the VAE optimizer init to pass all its parameters instead of just the encoders.
The UMAP runtime issue was due to the buffer of predictions not being cleared after they were written to disk.
I also added a species tag to the latent embeddings so we can map by species in addition to other categories.