### PR TITLE
Added parallel configuration for conditional layers

### DIFF
--- a/configs/model/experiment/adversarial-conditional.yaml
+++ b/configs/model/experiment/adversarial-conditional.yaml
@@ -1,0 +1,120 @@
+class_path: cmmvae.models.CMMVAEModel
+init_args:
+  kl_annealing_fn:
+    class_path: cmmvae.modules.base.annealing_fn.LinearKLAnnealingFn
+    init_args:
+      min_kl_weight: 0.1
+      max_kl_weight: 1.0
+      warmup_steps: 1e4
+      climax_steps: 4e4
+  record_gradients: false
+  adv_weight: 25
+  gradient_record_cap: 20
+  autograd_config:
+    class_path: cmmvae.config.AutogradConfig
+    init_args:
+      adversarial_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+      vae_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+      expert_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+  module:
+    class_path: cmmvae.modules.CMMVAE
+    init_args:
+      vae:
+        class_path: cmmvae.modules.CLVAE
+        init_args:
+          latent_dim: 128
+          encoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 512, 256 ]
+              dropout_rate: 0.0
+              use_batch_norm: True
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+              return_hidden: True
+          decoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128, 256, 512 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          conditional_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers:
+              - 128
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: True
+              activation_fn: null
+          conditionals:
+          - assay
+          - dataset_id
+          - donor_id
+          - species
+          - tissue
+          selection_order: null
+      experts:
+        class_path: cmmvae.modules.base.Experts
+        init_args:
+          experts:
+          - class_path: cmmvae.modules.base.Expert
+            init_args:
+              id: human
+              encoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 60530, 1024, 512 ]
+                  dropout_rate: [ 0.1, 0.0 ]
+                  use_batch_norm: True
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+              decoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 512, 1024, 60530 ]
+                  dropout_rate: 0.0
+                  use_batch_norm: False
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+          - class_path: cmmvae.modules.base.Expert
+            init_args:
+              id: mouse
+              encoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 52437, 1024, 512 ]
+                  dropout_rate: [ 0.1, 0.0 ]
+                  use_batch_norm: True
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+              decoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 512, 1024, 52437 ]
+                  dropout_rate: 0.0
+                  use_batch_norm: False
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+      adversarials:
+      - class_path: cmmvae.modules.base.FCBlockConfig
+        init_args:
+          layers: [ 256, 128, 64, 1 ]
+          dropout_rate: 0.0
+          use_batch_norm: False
+          use_layer_norm: False
+          activation_fn: torch.nn.Sigmoid

--- a/configs/model/parallel/adversarial-conditional.yaml
+++ b/configs/model/parallel/adversarial-conditional.yaml
@@ -61,9 +61,8 @@ init_args:
               use_layer_norm: True
               activation_fn: null
           concat_config:
-            class_path: cmmvae.modules.base.FCBlockConfig
+            class_path: cmmvae.modules.base.ConcatBlockConfig
             init_args:
-              layers: [ 128 ]
               dropout_rate: 0.0
               use_batch_norm: False
               use_layer_norm: False

--- a/configs/model/parallel/adversarial-conditional.yaml
+++ b/configs/model/parallel/adversarial-conditional.yaml
@@ -4,9 +4,9 @@ init_args:
     class_path: cmmvae.modules.base.annealing_fn.LinearKLAnnealingFn
     init_args:
       min_kl_weight: 0.1
-      max_kl_weight: 1.0
+      max_kl_weight: 0.5
       warmup_steps: 1e4
-      climax_steps: 4e4
+      climax_steps: 6e4
   record_gradients: false
   adv_weight: 25
   gradient_record_cap: 20
@@ -55,19 +55,27 @@ init_args:
           conditional_config:
             class_path: cmmvae.modules.base.FCBlockConfig
             init_args:
-              layers:
-              - 128
+              layers: [ 128 ]
               dropout_rate: 0.0
               use_batch_norm: False
               use_layer_norm: True
               activation_fn: null
+          concat_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
           conditionals:
           - assay
           - dataset_id
           - donor_id
           - species
           - tissue
-          selection_order: null
+          selection_order:
+          - parallel
       experts:
         class_path: cmmvae.modules.base.Experts
         init_args:
@@ -117,4 +125,7 @@ init_args:
           dropout_rate: 0.0
           use_batch_norm: False
           use_layer_norm: False
-          activation_fn: torch.nn.Sigmoid
+          activation_fn:
+          - torch.nn.ReLU
+          - torch.nn.ReLU
+          - torch.nn.Sigmoid

--- a/configs/model/parallel/conditional.yaml
+++ b/configs/model/parallel/conditional.yaml
@@ -1,0 +1,128 @@
+class_path: cmmvae.models.CMMVAEModel
+init_args:
+  kl_annealing_fn:
+    class_path: cmmvae.modules.base.annealing_fn.LinearKLAnnealingFn
+    init_args:
+      min_kl_weight: 0.1
+      max_kl_weight: 1.0
+      warmup_steps: 1e4
+      climax_steps: 4e4
+  record_gradients: false
+  adv_weight: 0
+  gradient_record_cap: 20
+  autograd_config:
+    class_path: cmmvae.config.AutogradConfig
+    init_args:
+      adversarial_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+      vae_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+      expert_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+  module:
+    class_path: cmmvae.modules.CMMVAE
+    init_args:
+      vae:
+        class_path: cmmvae.modules.CLVAE
+        init_args:
+          latent_dim: 128
+          encoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 512, 256 ]
+              dropout_rate: 0.0
+              use_batch_norm: True
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+              return_hidden: True
+          decoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128, 256, 512 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          conditional_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: True
+              activation_fn: null
+          concat_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          conditionals:
+          - assay
+          - dataset_id
+          - donor_id
+          - species
+          - tissue
+          selection_order:
+          - parallel
+      experts:
+        class_path: cmmvae.modules.base.Experts
+        init_args:
+          experts:
+          - class_path: cmmvae.modules.base.Expert
+            init_args:
+              id: human
+              encoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 60530, 1024, 512 ]
+                  dropout_rate: [ 0.1, 0.0 ]
+                  use_batch_norm: True
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+              decoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 512, 1024, 60530 ]
+                  dropout_rate: 0.0
+                  use_batch_norm: False
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+          - class_path: cmmvae.modules.base.Expert
+            init_args:
+              id: mouse
+              encoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 52437, 1024, 512 ]
+                  dropout_rate: [ 0.1, 0.0 ]
+                  use_batch_norm: True
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+              decoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 512, 1024, 52437 ]
+                  dropout_rate: 0.0
+                  use_batch_norm: False
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+      adversarials:
+      # - class_path: cmmvae.modules.base.FCBlockConfig
+      #   init_args:
+      #     layers: [ 256, 128, 64, 1 ]
+      #     dropout_rate: 0.0
+      #     use_batch_norm: False
+      #     use_layer_norm: False
+      #     activation_fn: torch.nn.Sigmoid

--- a/configs/model/parallel/conditional.yaml
+++ b/configs/model/parallel/conditional.yaml
@@ -61,9 +61,8 @@ init_args:
               use_layer_norm: True
               activation_fn: null
           concat_config:
-            class_path: cmmvae.modules.base.FCBlockConfig
+            class_path: cmmvae.modules.base.ConcatBlockConfig
             init_args:
-              layers: [ 128 ]
               dropout_rate: 0.0
               use_batch_norm: False
               use_layer_norm: False

--- a/scripts/gather-norms.py
+++ b/scripts/gather-norms.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+import pandas as pd
+
+# Replace with the path to your TensorBoard log file
+log_file = "/mnt/projects/debruinz_project/denhofja/cmmvae/lightning_logs/run-experiment/adversarial-conditional.5a9df4a./events.out.tfevents.1730760440.g001.clipper.gvsu.edu.3079995.0"
+data = []
+
+for event in tf.compat.v1.train.summary_iterator(log_file):
+    for value in event.summary.value:
+        # Modify 'grad_norm' to the exact tag name used for gradient norms in your logs
+        if "grad_norm" in value.tag:
+            data.append(
+                {"step": event.step, "grad_norm": value.simple_value, "tag": value.tag}
+            )
+
+# Convert to DataFrame and save to CSV
+df = pd.DataFrame(data)
+df.to_csv("gradient_data.json")

--- a/scripts/run-compare.sh
+++ b/scripts/run-compare.sh
@@ -105,7 +105,13 @@ do
     run_name="${run_name}.${commit_hash}"
   fi
 
-  version=$(find "$root_dir/$experiment" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | grep -E 'V[0-9]{3}$' | sort -V | tail -n 1 | sed -E 's/V([0-9]{3})$/\1/' | awk '{printf "V%03d", $1 + 1}')
+  ran_dirs=$(ls -d "$root_dir/$experiment/$run_name*")
+
+  if [ $? -ne 0 ]; then
+    version=V000
+  else
+    version=$(echo $ran_dirs | grep -E 'V[0-9]{3}$' | sort -V | tail -n 1 | sed -E 's/V([0-9]{3})$/\1/' | awk '{printf "V%03d", $1 + 1}')
+  fi
 
   echo "Processing: $file"
   command="scripts/run-snakemake.sh --config \

--- a/scripts/run-compare.sh
+++ b/scripts/run-compare.sh
@@ -1,33 +1,120 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-  echo "No argument provided for the name of the experiment!"
+debug=false
+append_commit_hash=true
+root_dir="${CMMVAE_ROOT_DIR}"
+experiment="${CMMVAE_EXPERIMENT_NAME}"
+data="${CMMVAE_DATA_CONFIG}"
+compare=""
+max_epochs="${CMMVAE_MAX_EPOCHS}"
+commit_hash=""
+
+if [ -z "${max_epochs}" ]; then
+  max_epochs=5
+else
+  echo "CMMVAE_MAX_EPOCHS is set to '$CMMVAE_MAX_EPOCHS'"
+fi
+
+if [ -z "${data}" ]; then
+  data=configs/data/local.yaml
+else
+  echo "CMMVAE_DATA_CONFIG is set to '$CMMVAE_DATA_CONFIG'"
+fi
+
+if [ -z "${root_dir}" ]; then
+  root_dir=lightning_logs
+else
+  echo "CMMVAE_ROOT_DIR is set to '$CMMVAE_ROOT_DIR'"
+fi
+
+if [ -z "${experiment}" ]; then
+  experiment=default
+else
+  echo "CMMVAE_EXPERIMENT_NAME is set to '$CMMVAE_EXPERIMENT_NAME'"
+fi
+
+for arg in "$@"
+do
+    case $arg in
+        --debug)
+            debug=true
+            shift
+            ;;
+        --no-commit-hash)
+            append_commit_hash=false
+            shift
+            ;;
+        root_dir=*)
+            root_dir="${arg#*=}"
+            shift
+            ;;
+        experiment=*)
+            experiment="${arg#*=}"
+            shift
+            ;;
+        compare=*)
+            compare="${arg#*=}"
+            shift
+            ;;
+        data=*)
+            data="${arg#*=}"
+            shift
+            ;;
+        max_epochs=*)
+            max_epochs="${arg#*=}"
+            shift
+            ;;
+        # *)
+        #     echo "Unknown argument: $arg"
+        #     ;;
+
+    esac
+done
+
+if [ -z "$compare" ]; then
+  echo "Please specify directory that contains model configs to compare."
   exit 1
 fi
 
-if [ -z "$2" ]; then
-  echo "No argument provided for model config filename!"
-  exit 1
+if [ "$append_commit_hash" = true ]; then
+  # Check if Git is installed
+  if ! command -v git &> /dev/null; then
+      echo "Error: Git is not installed. Please install Git to use this script or specify --no-commit-hash."
+      exit 1
+  fi
+
+  # Check if inside a Git repository
+  if ! git rev-parse --is-inside-work-tree &> /dev/null; then
+      echo "Error: This is not a Git repository. Please run the script inside a Git repository or specify --no-commit-hash."
+      exit 1
+  fi
+
+  # Fetch and show the latest commit hash
+  commit_hash=$(git rev-parse --short HEAD)
+  echo "Latest Commit Hash: $commit_hash"
+else
+  echo "Skipping commit hash display."
 fi
 
-experiment_name=$1
-compare_dir=$2
-
-shift 2
-
-root_dir=lightning_logs
-data=configs/data/local.yaml
-max_epochs="--trainer.max_epochs 5"
-
-for file in $compare_dir/*.yaml
+for file in $compare/*.yaml
 do
   run_name=$(basename "$file" .yaml)
-  version=$(ls -d "$root_dir/$experiment_name/$base_run_name"* | grep -E 'V[0-9]{3}$' | sort -V | tail -n 1 | sed -E 's/V([0-9]{3})$/\1/' | awk '{printf "V%03d", $1 + 1}')
+
+  if [ "$commit_hash" != "" ]; then
+    run_name="${run_name}.${commit_hash}"
+  fi
+
+  version=$(find "$root_dir/$experiment" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | grep -E 'V[0-9]{3}$' | sort -V | tail -n 1 | sed -E 's/V([0-9]{3})$/\1/' | awk '{printf "V%03d", $1 + 1}')
 
   echo "Processing: $file"
-  sbatch scripts/run-snakemake.sh --config \
-    root_dir="$root_dir" \
-    experiment_name="$experiment_name" \
-    run_name="${run_name}.${version}" \
-    train_command="fit --data $data --model $file $max_epochs $*"
+  command="scripts/run-snakemake.sh --config \
+    root_dir=${root_dir} \
+    experiment_name=${experiment} \
+    run_name=${run_name}.${version} \
+    train_command=\"fit --data $data --model $file --trainer.max_epochs $max_epochs $*\"
+    "
+  echo $command
+  if [ "$debug" = false ]; then
+    sbatch $command
+  fi
 done

--- a/scripts/run-compare.sh
+++ b/scripts/run-compare.sh
@@ -10,20 +10,24 @@ if [ -z "$2" ]; then
   exit 1
 fi
 
-for file in "$2"/*.yaml
-do
-    filename=$(basename "$file" .yaml)
-    echo "Processing: $filename"
-    sbatch scripts/run-snakemake.sh --config \
-        experiment_name=$1\
-        run_name=$filename \
-        root_dir=lightning_logs \
-        train_command=\
-"\
-fit \
---data configs/data/local.yaml \
---model $file \
---trainer.max_epochs 5 \
-"
+experiment_name=$1
+compare_dir=$2
 
+shift 2
+
+root_dir=lightning_logs
+data=configs/data/local.yaml
+max_epochs="--trainer.max_epochs 5"
+
+for file in $compare_dir/*.yaml
+do
+  run_name=$(basename "$file" .yaml)
+  version=$(ls -d "$root_dir/$experiment_name/$base_run_name"* | grep -E 'V[0-9]{3}$' | sort -V | tail -n 1 | sed -E 's/V([0-9]{3})$/\1/' | awk '{printf "V%03d", $1 + 1}')
+
+  echo "Processing: $file"
+  sbatch scripts/run-snakemake.sh --config \
+    root_dir="$root_dir" \
+    experiment_name="$experiment_name" \
+    run_name="${run_name}.${version}" \
+    train_command="fit --data $data --model $file $max_epochs $*"
 done

--- a/scripts/run-compare.sh
+++ b/scripts/run-compare.sh
@@ -8,6 +8,7 @@ data="${CMMVAE_DATA_CONFIG}"
 compare=""
 max_epochs="${CMMVAE_MAX_EPOCHS}"
 commit_hash=""
+extra_args=""
 
 if [ -z "${max_epochs}" ]; then
   max_epochs=5
@@ -64,10 +65,10 @@ do
             max_epochs="${arg#*=}"
             shift
             ;;
-        # *)
-        #     echo "Unknown argument: $arg"
-        #     ;;
-
+        *)
+            extra_args="$extra_args $arg"
+            shift
+            ;;
     esac
 done
 
@@ -111,10 +112,10 @@ do
     root_dir=${root_dir} \
     experiment_name=${experiment} \
     run_name=${run_name}.${version} \
-    train_command=\"fit --data $data --model $file --trainer.max_epochs $max_epochs $*\"
-    "
+    train_command=\"fit --model $file --data $data --trainer.max_epochs $max_epochs $extra_args\"
+  "
   echo $command
   if [ "$debug" = false ]; then
-    sbatch $command
+    eval "sbatch $command"
   fi
 done

--- a/src/cmmvae/models/cmmvae_model.py
+++ b/src/cmmvae/models/cmmvae_model.py
@@ -206,6 +206,7 @@ class CMMVAEModel(BaseModel):
         qz, pz, z, xhats, hidden_representations = self.module(
             x=x, metadata=metadata, expert_id=expert_id
         )
+        # assert isinstance(qz, torch.distributions.Normal)
 
         if x.layout == torch.sparse_csr:
             x = x.to_dense()
@@ -214,6 +215,10 @@ class CMMVAEModel(BaseModel):
         main_loss_dict = self.module.vae.elbo(
             qz, pz, x, xhats[expert_id], self.kl_annealing_fn.kl_weight
         )
+
+        main_loss_dict["Mean"] = qz.mean.mean()
+        main_loss_dict["Variance"] = qz.variance.mean()
+
         total_loss = main_loss_dict[RK.LOSS]
 
         adv_loss = None

--- a/src/cmmvae/modules/base/__init__.py
+++ b/src/cmmvae/modules/base/__init__.py
@@ -10,6 +10,7 @@ from cmmvae.modules.base.components import (
     ConditionalLayer,
     ConditionalLayers,
     GradientReversalFunction,
+    ConcatBlockConfig,
 )
 
 from cmmvae.modules.base.annealing_fn import KLAnnealingFn, LinearKLAnnealingFn
@@ -17,6 +18,7 @@ from cmmvae.modules.base.annealing_fn import KLAnnealingFn, LinearKLAnnealingFn
 __all__ = [
     "ConditionalLayer",
     "ConditionalLayers",
+    "ConcatBlockConfig",
     "Encoder",
     "Expert",
     "Experts",

--- a/workflow/profile/slurm/config.yaml
+++ b/workflow/profile/slurm/config.yaml
@@ -26,36 +26,36 @@ jobs: 10
 set-resources:
   diff_expression:
     partition: bigmem
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: ""
     cpus_per_task: 1
   train:
     partition: gpu
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: tesla_v100s:1
-    cpus_per_task: 12
+    cpus_per_task: 6
   predict:
     partition: gpu
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: 1
-    cpus_per_task: 12
+    cpus_per_task: 6
   merge_predictions:
     partition: all
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: ""
     cpus_per_task: 1
   correlations:
     partition: gpu
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: tesla_v100s:1
-    cpus_per_task: 12
+    cpus_per_task: 6
   umap_predictions:
     partition: all
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: ""
     cpus_per_task: 40
   meta_discriminators:
     partition: gpu
-    mem: 179GB
+    mem: 100GB
     gpus_per_node: tesla_v100s:1
-    cpus_per_task: 12
+    cpus_per_task: 6


### PR DESCRIPTION
CLVAE now allows parallel selection_order which concat's each output from the conditional layer. In order to have parallel layers specify selection_order to be [parallel] and specify the concat_config which consists of the transformation's to apply to the linear layer after concatenation to the decoder.