### PR TITLE
Moved commit_hash in front of run_name to maintain order

### DIFF
--- a/scripts/run-compare.sh
+++ b/scripts/run-compare.sh
@@ -99,7 +99,7 @@ do
   run_name=$(basename "$file" .yaml)
 
   if [ "$commit_hash" != "" ]; then
-    run_name="${run_name}.${commit_hash}"
+    run_name="${commit_hash}.${run_name}"
   fi
 
   ran_dirs=$(ls -d "$root_dir/$experiment/$run_name"* 2>/dev/null)


### PR DESCRIPTION
Tensorboard plots are not in order of version number due to the commit hash changing. To keep versions in sequence the commit hash is now infront of the run-name.