### PR TITLE
Adds custom dev_stage metadata tag pre-processing script

### DIFF
--- a/scripts/data-preprocessing/data_filtering_functions.py
+++ b/scripts/data-preprocessing/data_filtering_functions.py
@@ -6,11 +6,11 @@ import pandas as pd
 import pandas.core.groupby.generic as gb
 from collections import defaultdict
 from data_processing_functions import extract_file_number
+from cmmvae.constants import REGISTRY_KEYS as RK
 
 TRAIN_DATA_FILES = set(range(1, 14))
-GROUPING_COLUMNS = ["sex", "tissue", "cell_type", "assay"]
 MIN_SAMPLE_SIZE = 100
-MAX_SAMPLE_SIZE = 10000
+MAX_SAMPLE_SIZE = 1000
 SPECIES_SAMPLE_SIZE = {"human": 60530, "mouse": 52437}
 
 def get_train_data_ids(files: tuple[str]) -> set[int]:
@@ -53,7 +53,7 @@ def filter_into_groups(dfs: dict[str, pd.DataFrame]):
     
     grouped = {}
     for specie, data in dfs.items():
-        grouped[specie] = data.groupby(GROUPING_COLUMNS)
+        grouped[specie] = data.groupby(RK.FILTER_CATEGORIES)
 
     return grouped
 
@@ -86,7 +86,7 @@ def save_grouped_data(groups: dict[tuple[str], dict[str, np.ndarray]], dfs: dict
     
     with open(os.path.join(save_dir, "group_references.csv"), "w") as file:
         writer = csv.writer(file)
-        writer.writerow(["group_id", "num_samples"] + GROUPING_COLUMNS)
+        writer.writerow(["group_id", "num_samples"] + RK.FILTER_CATEGORIES)
         for i, gid in enumerate(groups.keys(), start=1):
             for specie, idx in groups[gid].items():                
                 df = dfs[specie].iloc[idx]

--- a/scripts/data-preprocessing/dev_stage_tagging.py
+++ b/scripts/data-preprocessing/dev_stage_tagging.py
@@ -1,0 +1,113 @@
+import argparse as ap
+import glob
+import os
+import pandas as pd
+
+import cellxgene_ontology_guide.ontology_parser as op
+
+HUMAN_EMBRYO = "HsapDv:0000002"
+HUMAN_FETAL = "HsapDv:0000037"
+HUMAN_IMMATURE = "HsapDv:0000264"
+HUMAN_YOUNG_ADULT = "HsapDv:0000266"
+HUMAN_MIDDLE_ADULT = "HsapDv:0000267"
+HUMAN_LATE_ADULT = "HsapDv:0000227"
+
+MOUSE_EMBRYO = "MmusDv:0000002"
+MOUSE_FETAL = "MmusDv:0000031"
+MOUSE_IMMATURE = "MmusDv:0000043"
+MOUSE_YOUNG_ADULT = "MmusDv:0000153"
+MOUSE_MIDDLE_ADULT = "MmusDv:0000135"
+MOUSE_LATE_ADULT = "MmusDv:0000134"
+
+def tag_human(term_id):
+    parser = op.OntologyParser()
+    if term_id == "unknown":
+        return "unknown"
+    elif term_id in parser.get_term_descendants(HUMAN_EMBRYO):
+        return "embryonic"
+    elif term_id in parser.get_term_descendants(HUMAN_FETAL):
+        return "fetal"
+    elif term_id in parser.get_term_descendants(HUMAN_IMMATURE):
+        return "immature"
+    elif term_id in parser.get_term_descendants(HUMAN_YOUNG_ADULT):
+        return "young_adult"
+    elif term_id in parser.get_term_descendants(HUMAN_MIDDLE_ADULT):
+        return "middle_adult"
+    elif term_id in parser.get_term_descendants(HUMAN_LATE_ADULT):
+        return "late_adult"
+    else:
+        if parser.is_term_deprecated(term_id):
+            replacement = parser.get_term_replacement(term_id)
+            if replacement is not None:
+                return tag_human(replacement)
+            else:
+                consider = parser.get_term_metadata(term_id)["consider"]
+                if consider is not None:
+                    return tag_human(consider[0])
+                else:
+                    return "unknown"
+        return "unknown"
+    
+def tag_mouse(term_id):
+    parser = op.OntologyParser()
+    if term_id == "unknown":
+        return "unknown"
+    elif term_id in parser.get_term_descendants(MOUSE_EMBRYO):
+        return "embryonic"
+    elif term_id in parser.get_term_descendants(MOUSE_FETAL):
+        return "fetal"
+    elif term_id in parser.get_term_descendants(MOUSE_IMMATURE):
+        return "immature"
+    elif term_id in parser.get_term_descendants(MOUSE_YOUNG_ADULT):
+        return "young_adult"
+    elif term_id in parser.get_term_descendants(MOUSE_MIDDLE_ADULT):
+        return "middle_adult"
+    elif term_id in parser.get_term_descendants(MOUSE_LATE_ADULT):
+        return "late_adult"
+    else:
+        if parser.is_term_deprecated(term_id):
+            replacement = parser.get_term_replacement(term_id)
+            if replacement is not None:
+                return tag_mouse(replacement)
+            else:
+                consider = parser.get_term_metadata(term_id)["consider"]
+                if consider is not None:
+                    return tag_mouse(consider[0])
+                else:
+                    return "unknown"
+        return "unknown"
+                
+def main(directory):
+
+    human_metadata = glob.glob(
+        os.path.join(
+            directory, "human*.pkl"
+        )
+    )
+    mouse_metadata = glob.glob(
+        os.path.join(
+            directory, "mouse*.pkl"
+        )
+    )
+    for file in human_metadata:
+        df = pd.read_pickle(file)
+        df["dev_stage"] = df["development_stage_ontology_term_id"].apply(tag_human)
+        # assert len(df[(df["dev_stage"] == "unknown") & (df["development_stage"] != "unknown")]) == 0
+        df.to_pickle(file, protocol=4)
+
+    for file in mouse_metadata:
+        df = pd.read_pickle(file)
+        df["dev_stage"] = df["development_stage_ontology_term_id"].apply(tag_mouse)
+        # assert len(df[(df["dev_stage"] == "unknown") & (df["development_stage"] != "unknown")]) == 0
+        df.to_pickle(file, protocol=4)
+
+if __name__ == "__main__":
+    parser = ap.ArgumentParser()
+    parser.add_argument(
+        "--directory",
+        type=str,
+        required=True,
+        help="Directory to load data from."
+    )
+    args = parser.parse_args()
+    main(args.directory)

--- a/src/cmmvae/constants.py
+++ b/src/cmmvae/constants.py
@@ -59,6 +59,7 @@ class REGISTRY_KEYS_NT(NamedTuple):
     """Key for the h5py file umap embeddings"""
     PREDICT_SAMPLES: str = "data"
     """Key for the h5py file predict samples"""
+    FILTER_CATEGORIES: list = ["sex", "dev_stage", "tissue", "cell_type", "assay"]
 
 
 # Instance of _REGISTRY_KEYS_NT for use in the application

--- a/src/cmmvae/runners/correlations.py
+++ b/src/cmmvae/runners/correlations.py
@@ -23,7 +23,7 @@ def setup_datapipes(data_dir: str, human_masks: str, mouse_masks: str):
         directory_path=data_dir,
         npz_masks=[f"{human_mask}.npz" for human_mask in human_masks],
         metadata_masks=[f"{human_mask}.pkl" for human_mask in human_masks],
-        batch_size=10000,
+        batch_size=1000,
         allow_partials=True,
         shuffle=False,
         return_dense=True,
@@ -33,7 +33,7 @@ def setup_datapipes(data_dir: str, human_masks: str, mouse_masks: str):
         directory_path=data_dir,
         npz_masks=[f"{mouse_mask}.npz" for mouse_mask in mouse_masks],
         metadata_masks=[f"{mouse_mask}.pkl" for mouse_mask in mouse_masks],
-        batch_size=10000,
+        batch_size=1000,
         allow_partials=True,
         shuffle=False,
         return_dense=True,
@@ -45,7 +45,7 @@ def setup_datapipes(data_dir: str, human_masks: str, mouse_masks: str):
 def setup_dataloaders(data_dir: str):
 
     gids = np.random.choice(
-        np.arange(1, 252), size=25, replace=False
+        np.arange(1, 158), size=16, replace=False
     )
     
     human_masks = [f"human*_{gid}" for gid in gids]


### PR DESCRIPTION
This PR adds the pre-processing script used to tag samples with a dev_stage category based on their dev_stage ontology term ID.

The data filtering and correlations scripts have also been updated with sensible sample sizes, prettier plots, and a new constant registry key for the data filtering categories instead of several global constants.