### PR TITLE
Adds multi-headed adversarial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 **/.pytest_cache/
 **.egg-info
 **/slurm-*.sh
-**/pytest-test.*.out
+**/*.out
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Snakefile
+++ b/Snakefile
@@ -115,7 +115,7 @@ MERGE_KEY_COMMAND = " ".join(f"--keys {merge_key}" for merge_key in MERGE_KEYS)
 rule all:
     input:
         EVALUATION_FILES,
-        CORRELATION_FILES
+        # CORRELATION_FILES
 
 ## Define the rule for finding unique expressions for conditional layers
 ## The output includes paths to the conditional layer expressions used.
@@ -160,34 +160,34 @@ rule predict:
 
 ## Define the rule for getting R^2 correlations on the filtered data
 ## This rule outputs correlation scores per filtered data group
-rule correlations:
-    input:
-        ckpt_path=CKPT_PATH,
-    output:
-        os.path.join(CORRELATION_DIR, "correlations_complete.log")
-    params:
-        command=TRAIN_COMMAND.lstrip('fit'),
-        data=CORRELATION_DATA,
-        save_dir=CORRELATION_DIR,
-    shell:
-        """
-        mkdir -p {CORRELATION_DIR}
-        cmmvae workflow correlations {params.command} --ckpt_path {input.ckpt_path} --correlation_data {params.data} --save_dir {params.save_dir}
-        touch {output}
-        """
+# rule correlations:
+#     input:
+#         ckpt_path=CKPT_PATH,
+#     output:
+#         os.path.join(CORRELATION_DIR, "correlations_complete.log")
+#     params:
+#         command=TRAIN_COMMAND.lstrip('fit'),
+#         data=CORRELATION_DATA,
+#         save_dir=CORRELATION_DIR,
+#     shell:
+#         """
+#         mkdir -p {CORRELATION_DIR}
+#         cmmvae workflow correlations {params.command} --ckpt_path {input.ckpt_path} --correlation_data {params.data} --save_dir {params.save_dir}
+#         touch {output}
+#         """
 
-rule run_correlations:
-    input:
-        rules.correlations.output
-    output:
-        CORRELATION_FILES,
-    params:
-        directory=CORRELATION_DIR,
-    shell:
-        """
-        mkdir -p {CORRELATION_DIR}
-        cmmvae workflow run-correlations --directory {params.directory}
-        """
+# rule run_correlations:
+#     input:
+#         rules.correlations.output
+#     output:
+#         CORRELATION_FILES,
+#     params:
+#         directory=CORRELATION_DIR,
+#     shell:
+#         """
+#         mkdir -p {CORRELATION_DIR}
+#         cmmvae workflow run-correlations --directory {params.directory}
+#         """
 
 ## Define the rule for generating UMAP visualizations from the merged predictions.
 ## This rule produces UMAP images for each combination of category and merge key.

--- a/configs/data/local_human.yaml
+++ b/configs/data/local_human.yaml
@@ -1,0 +1,46 @@
+class_path: cmmvae.data.local.SpeciesDataModule
+init_args:
+  species:
+  - class_path: cmmvae.data.local.SpeciesManager
+    init_args:
+      name: human
+      return_dense: true
+      batch_size: 128
+      directory_path: /mnt/projects/debruinz_project/july2024_census_data/subset
+      train_npz_masks:
+      - human_counts_1.npz
+      - human_counts_2.npz
+      - human_counts_3.npz
+      - human_counts_4.npz
+      - human_counts_5.npz
+      - human_counts_6.npz
+      - human_counts_7.npz
+      - human_counts_8.npz
+      - human_counts_9.npz
+      - human_counts_10.npz
+      - human_counts_11.npz
+      - human_counts_12.npz
+      - human_counts_13.npz
+      train_metadata_masks:
+      - human_metadata_1.pkl
+      - human_metadata_2.pkl
+      - human_metadata_3.pkl
+      - human_metadata_4.pkl
+      - human_metadata_5.pkl
+      - human_metadata_6.pkl
+      - human_metadata_7.pkl
+      - human_metadata_8.pkl
+      - human_metadata_9.pkl
+      - human_metadata_10.pkl
+      - human_metadata_11.pkl
+      - human_metadata_12.pkl
+      - human_metadata_13.pkl
+      val_npz_masks: human_counts_14.npz
+      val_metadata_masks: human_metadata_14.pkl
+      test_npz_masks: human_counts_15.npz
+      test_metadata_masks: human_metadata_15.pkl
+      verbose: false
+  num_workers: 2
+  n_val_workers: 1
+  n_test_workers: 1
+  conditionals_directory: /mnt/projects/debruinz_project/tony_boos/3m_expressions

--- a/configs/model/human_only.yaml
+++ b/configs/model/human_only.yaml
@@ -1,0 +1,157 @@
+class_path: cmmvae.models.CMMVAEModel
+init_args:
+  kl_annealing_fn:
+    class_path: cmmvae.modules.base.KLAnnealingFn
+    init_args:
+      kl_weight: 1.0
+  record_gradients: false
+  adv_weight: 1.0
+  gradient_record_cap: 20
+  autograd_config:
+    class_path: cmmvae.config.AutogradConfig
+    init_args:
+      adversarial_gradient_clip:
+          class_path: cmmvae.config.GradientClipConfig
+          init_args:
+            val: 10
+            algorithm: norm
+      expert_gradient_clip:
+          class_path: cmmvae.config.GradientClipConfig
+          init_args:
+            val: 10
+            algorithm: norm
+      vae_gradient_clip:
+        class_path: cmmvae.config.GradientClipConfig
+        init_args:
+          val: 10
+          algorithm: norm
+  module:
+    class_path: cmmvae.modules.CMMVAE
+    init_args:
+      vae:
+        class_path: cmmvae.modules.CLVAE
+        init_args:
+          latent_dim: 128
+          encoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 512, 256 ]
+              dropout_rate: 0.0
+              use_batch_norm: True
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+              return_hidden: True
+          hidden_z: True
+          decoder_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128, 256, 512 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          conditional_config:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: True
+              activation_fn: null
+          concat_config:
+            class_path: cmmvae.modules.base.ConcatBlockConfig
+            init_args:
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          conditionals_directory: /mnt/projects/debruinz_project/tony_boos/3m_expressions
+          conditionals:
+          - assay
+          - dataset_id
+          - dev_stage
+          - disease
+          - donor_id
+          - species
+          - sex
+          - tissue_general
+          selection_order:
+          - parallel
+      experts:
+        class_path: cmmvae.modules.base.Experts
+        init_args:
+          experts:
+          - class_path: cmmvae.modules.base.Expert
+            init_args:
+              id: human
+              encoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 60530, 1024, 512 ]
+                  dropout_rate: 0.1
+                  use_batch_norm: True
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+              decoder_config:
+                class_path: cmmvae.modules.base.FCBlockConfig
+                init_args:
+                  layers: [ 512, 1024, 60530 ]
+                  dropout_rate: 0.0
+                  use_batch_norm: False
+                  use_layer_norm: False
+                  activation_fn: torch.nn.ReLU
+      adversarials:
+      - class_path: cmmvae.modules.base.Adversarial
+        init_args:
+          encoder:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 256, 128, 64 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          heads:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [64] # Will be auto-configured by the Adversarial
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: null
+          conditions:
+          - assay
+          - dataset_id
+          - dev_stage
+          - disease
+          - donor_id
+          - sex
+          - tissue_general
+          labels_dir: /mnt/projects/debruinz_project/tony_boos/3m_expressions
+      - class_path: cmmvae.modules.base.Adversarial
+        init_args:
+          encoder:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [ 128, 64 ]
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: torch.nn.ReLU
+          heads:
+            class_path: cmmvae.modules.base.FCBlockConfig
+            init_args:
+              layers: [64] # Will be auto-configured by the Adversarial
+              dropout_rate: 0.0
+              use_batch_norm: False
+              use_layer_norm: False
+              activation_fn: null
+          conditions:
+          - assay
+          - dataset_id
+          - dev_stage
+          - disease
+          - donor_id
+          - sex
+          - tissue_general
+          labels_dir: /mnt/projects/debruinz_project/tony_boos/3m_expressions

--- a/src/cmmvae/modules/base/__init__.py
+++ b/src/cmmvae/modules/base/__init__.py
@@ -2,6 +2,7 @@
     This module holds the building block nn.Modules and functions for training.
 """
 from cmmvae.modules.base.components import (
+    Adversarial,
     Encoder,
     FCBlock,
     FCBlockConfig,
@@ -16,6 +17,7 @@ from cmmvae.modules.base.components import (
 from cmmvae.modules.base.annealing_fn import KLAnnealingFn, LinearKLAnnealingFn
 
 __all__ = [
+    "Adversarial",
     "ConditionalLayer",
     "ConditionalLayers",
     "ConcatBlockConfig",

--- a/src/cmmvae/modules/cmmvae.py
+++ b/src/cmmvae/modules/cmmvae.py
@@ -5,13 +5,9 @@ import pandas as pd
 import torch
 from torch import nn
 
-from cmmvae.modules.base import Experts, FCBlock, FCBlockConfig
+from cmmvae.modules.base import Experts, FCBlockConfig, Adversarial
 from cmmvae.modules import CLVAE
 from cmmvae.constants import REGISTRY_KEYS as RK
-
-
-adversarial_TYP = Union[Optional[FCBlockConfig], list[Optional[FCBlockConfig]]]
-
 
 class CMMVAE(nn.Module):
     """
@@ -41,18 +37,15 @@ class CMMVAE(nn.Module):
         self,
         vae: CLVAE,
         experts: Experts,
-        adversarials: adversarial_TYP = None,
+        adversarials: Optional[list[Adversarial]] = None,
     ):
         super().__init__()
         self.vae = vae
         self.experts = experts
-        self.adversarials = None
 
-        if adversarials:
-            if not isinstance(adversarials, list):
-                adversarials = [adversarials]
+        if adversarials is not None:
             self.adversarials = nn.ModuleList(
-                [FCBlock(config) for config in adversarials if config]
+                [adv for adv in adversarials if adv]
             )
 
     def forward(

--- a/src/cmmvae/modules/vae.py
+++ b/src/cmmvae/modules/vae.py
@@ -141,14 +141,8 @@ class BaseVAE(nn.Module):
             x = x.to_dense()
 
         recon_loss = F.mse_loss(xhat, x, reduction="sum")
-        # recon_loss = F.mse_loss(xhat, x, reduction="none")
-        # recon_loss = recon_loss.sum(dim=1)
 
         loss = recon_loss + (kl_weight * z_kl_div)
-        # loss = torch.mean(z_kl_div * kl_weight + recon_loss)
-
-        recon_loss = recon_loss / x.numel()
-        # recon_loss = recon_loss.mean()
 
         return {
             RK.LOSS: loss,

--- a/src/cmmvae/runners/cli.py
+++ b/src/cmmvae/runners/cli.py
@@ -130,6 +130,11 @@ class CMMVAECli(plcli.LightningCLI):
             return
 
         best_model_path = self.trainer.checkpoint_callback.best_model_path
+        best_model = os.path.basename(best_model_path).split('_')[-1].split('.')[0]
+        best_model_log = os.path.join(
+            os.path.dirname(best_model_path), f"best_model_{best_model}.log"
+        )
+        open(best_model_log, "w").close()
         new_best_model_path = os.path.join(
             os.path.dirname(best_model_path), "best_model.ckpt"
         )

--- a/workflow/profile/slurm/config.yaml
+++ b/workflow/profile/slurm/config.yaml
@@ -9,7 +9,6 @@ cluster:
     --output=.cmmvae/logs/{rule}/job.%j.out
     --error=.cmmvae/logs/{rule}/job.%j.err
     --gpus-per-node={resources.gpus_per_node}
-    --account=account
     --ntasks=1
     --nodes=1
     --time={resources.runtime}


### PR DESCRIPTION
This pull request adds a multi-headed approach for the adversarial feedback. It also allows an adversary to be attached to the sampled latent vector (pre-conditional layers), does some minor cleanup, and makes some small changes to the logging titles.

Adds:
- Adversarial class with multiple output heads
- Human-only data and model configs

Logging:
- Differentiates between discriminator and generator losses
- Removes redundant Tensorboard card titles
- Adds log file to checkpoints dir to identify which epoch was the best

Cleanup:
- Removed old non-GRF adversarial feedback calculations
- Disables non-functioning Correlations rule in Snakemake
- Removes commented code from the ELBO loss of previous loss calculations
- Removes faulty 'account' flag from the SLURM config
- Updates the gitignore to ignore all .out files